### PR TITLE
Added multiValue flag to files.suffixes in openapi sonar plugin

### DIFF
--- a/sonar-openapi-plugin/src/main/java/org/sonar/plugins/openapi/OpenApiPlugin.java
+++ b/sonar-openapi-plugin/src/main/java/org/sonar/plugins/openapi/OpenApiPlugin.java
@@ -38,10 +38,11 @@ public class OpenApiPlugin implements Plugin {
       PropertyDefinition.builder(FILE_SUFFIXES_KEY)
         .index(10)
         .name("File Suffixes")
-        .description("Comma-separated list of suffixes of OpenAPI files to analyze.")
+        .description("A list of suffixes of OpenAPI files to analyze.")
         .category(OPENAPI_CATEGORY)
         .subCategory(GENERAL)
         .onQualifiers(Qualifiers.PROJECT)
+        .multiValues(true)
         .defaultValue("yaml,json")
         .build(),
       PropertyDefinition.builder(OpenApiScannerSensor.V2_PATH_KEY)


### PR DESCRIPTION
The sonar.openapi.files.suffixes property should be threatened as a multiValue property in its definition. It is accessed with getStringArray() so there is nothing to change when accessing the property. 
Fixing this resolves printing warnings on every Sonar scan with a server having this plugin enabled.