### PR TITLE
Bug fix: l.o.c. reporting

### DIFF
--- a/openapi-front-end/src/main/java/org/sonar/openapi/metrics/FileLinesVisitor.java
+++ b/openapi-front-end/src/main/java/org/sonar/openapi/metrics/FileLinesVisitor.java
@@ -86,7 +86,9 @@ public class FileLinesVisitor extends OpenApiVisitor {
   }
 
   private void addTokenLines(Token token, Set<Integer> lines) {
-    String[] tokenLines = token.getValue().split("\n", -1);
+    // String tokens are rather complicated in Yaml. We need to work on the original value to reason on lines,
+    // and remove any trailing newline that could be left by the parser
+    String[] tokenLines = token.getOriginalValue().trim().split("\n", -1);
     for (int line = token.getLine(); line < token.getLine() + tokenLines.length; line++) {
       lines.add(line);
     }

--- a/openapi-front-end/src/test/java/org/sonar/openapi/metrics/FileLinesVisitorTest.java
+++ b/openapi-front-end/src/test/java/org/sonar/openapi/metrics/FileLinesVisitorTest.java
@@ -46,4 +46,24 @@ public class FileLinesVisitorTest {
     assertThat(visitor.getLinesWithNoSonar()).hasSize(2);
     assertThat(visitor.getLinesWithNoSonar()).containsOnly(9, 12);
   }
+
+  @Test
+  public void correctly_reports_strings_with_embedded_newline() {
+    FileLinesVisitor visitor = new FileLinesVisitor();
+
+    TestOpenApiVisitorRunner.scanFile(new File(BASE_DIR, "embedded-newlines-lines.yaml"), visitor);
+
+    assertThat(visitor.getLinesOfCode()).hasSize(16);
+    assertThat(visitor.getLinesOfCode()).containsOnly(1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 17, 18, 19);
+  }
+
+  @Test
+  public void correctly_reports_multiline_strings() {
+    FileLinesVisitor visitor = new FileLinesVisitor();
+
+    TestOpenApiVisitorRunner.scanFile(new File(BASE_DIR, "multiline-lines.yaml"), visitor);
+
+    assertThat(visitor.getLinesOfCode()).hasSize(18);
+    assertThat(visitor.getLinesOfCode()).containsOnly(1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15, 16, 19, 20, 21);
+  }
 }

--- a/openapi-front-end/src/test/resources/metrics/embedded-newlines-lines.yaml
+++ b/openapi-front-end/src/test/resources/metrics/embedded-newlines-lines.yaml
@@ -1,0 +1,18 @@
+openapi: "3.0.1"
+x-no-sonar: SomeId
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+paths:
+  /pets:
+    # a comment line
+    x-sonar-disable: SomeId
+    get:
+      responses:
+        x-sonar-enable: SomeId
+        '200':
+          description: "some response\nwith newlines"
+  #
+  # another comment line
+  /newpets:
+    $ref: '#/paths/~1pets'

--- a/openapi-front-end/src/test/resources/metrics/multiline-lines.yaml
+++ b/openapi-front-end/src/test/resources/metrics/multiline-lines.yaml
@@ -1,0 +1,20 @@
+openapi: "3.0.1"
+x-no-sonar: SomeId
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+paths:
+  /pets:
+    # a comment line
+    x-sonar-disable: SomeId
+    get:
+      responses:
+        x-sonar-enable: SomeId
+        '200':
+          description: |
+            some multiline
+            description
+  #
+  # another comment line
+  /newpets:
+    $ref: '#/paths/~1pets'


### PR DESCRIPTION
Fix incorrect reporting of line of codes metric in case
the file contains a double-quote encoded string that contains
newline characters.